### PR TITLE
join and leave events

### DIFF
--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -5,14 +5,16 @@ import { Button } from 'react-bootstrap';
 import { useRouter } from 'next/navigation';
 import EventCard from '../../components/event/eventCard';
 import { getEvents } from '../../utils/data/eventData';
+import { useAuth } from '../../utils/context/authContext';
 
 function Home() {
   const [events, setEvents] = useState([]);
   const router = useRouter();
+  const { user } = useAuth();
 
   useEffect(() => {
-    getEvents().then((data) => setEvents(data));
-  }, []);
+    getEvents(user.uid).then((data) => setEvents(data));
+  }, [user.uid]);
 
   const onDelete = () => {
     getEvents().then((data) => setEvents(data));
@@ -30,7 +32,7 @@ function Home() {
       <h1>Events</h1>
       {events.map((event) => (
         <section key={`event--${event.id}`} className="event">
-          <EventCard description={event.description} date={event.date} time={event.time} gameTitle={event.game.title} eventId={event.id} onDelete={onDelete} />
+          <EventCard description={event.description} date={event.date} time={event.time} gameTitle={event.game.title} eventId={event.id} onDelete={onDelete} joined={event.joined} setEvents={setEvents} />
         </section>
       ))}
     </article>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -8,6 +8,7 @@ import { useAuth } from '@/utils/context/authContext';
 
 function Home() {
   const { user } = useAuth();
+  console.log(user);
 
   return (
     <div

--- a/src/components/event/eventCard.js
+++ b/src/components/event/eventCard.js
@@ -2,10 +2,12 @@ import { useRouter } from 'next/navigation';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Card, Button } from 'react-bootstrap';
-import { deleteEvent } from '../../utils/data/eventData';
+import { deleteEvent, joinEvent, leaveEvent } from '../../utils/data/eventData';
+import { useAuth } from '../../utils/context/authContext';
 
-function EventCard({ description, date, time, gameTitle, eventId, onDelete }) {
+function EventCard({ description, date, time, gameTitle, eventId, onDelete, joined, setEvents }) {
   const router = useRouter();
+  const { user } = useAuth();
 
   const handleEdit = () => {
     router.push(`/events/edit/${eventId}`);
@@ -15,6 +17,14 @@ function EventCard({ description, date, time, gameTitle, eventId, onDelete }) {
     deleteEvent(eventId).then(onDelete);
   };
 
+  const handleJoin = () => {
+    joinEvent(eventId, user.uid, setEvents);
+  };
+
+  const handleLeave = () => {
+    leaveEvent(eventId, user.uid, setEvents);
+  };
+
   return (
     <Card className="text-center">
       <Card.Header>{description}</Card.Header>
@@ -22,7 +32,18 @@ function EventCard({ description, date, time, gameTitle, eventId, onDelete }) {
         <Card.Text>Date: {date}</Card.Text>
         <Card.Text>Time: {time}</Card.Text>
         <Card.Text>Game Title: {gameTitle}</Card.Text>
-        <Button onClick={handleEdit}>Edit</Button>
+        <Button onClick={handleEdit} className="mx-2">
+          Edit
+        </Button>
+        {joined ? (
+          <Button onClick={handleLeave} variant="warning">
+            Leave
+          </Button>
+        ) : (
+          <Button onClick={handleJoin} variant="success">
+            Join
+          </Button>
+        )}
         <Button className="mx-2" onClick={handleDelete}>
           Delete
         </Button>
@@ -38,6 +59,8 @@ EventCard.propTypes = {
   gameTitle: PropTypes.string.isRequired,
   eventId: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
+  joined: PropTypes.bool.isRequired,
+  setEvents: PropTypes.func.isRequired,
 };
 
 export default EventCard;

--- a/src/utils/context/authContext.js
+++ b/src/utils/context/authContext.js
@@ -32,9 +32,7 @@ function AuthProvider(props) {
       if (fbUser) {
         setOAuthUser(fbUser);
         checkUser(fbUser.uid).then((gamerInfo) => {
-          let userObj = {};
-          userObj = { fbUser, uid: fbUser.uid, ...gamerInfo };
-          setUser(userObj);
+          setUser({ fbUser, uid: fbUser.uid, ...gamerInfo });
         });
       } else {
         setOAuthUser(false);

--- a/src/utils/data/eventData.js
+++ b/src/utils/data/eventData.js
@@ -1,8 +1,13 @@
 import { clientCredentials } from '../client';
 
-const getEvents = () =>
+const getEvents = (uid) =>
+  // eslint-disable-next-line no-new
   new Promise((resolve, reject) => {
-    fetch(`${clientCredentials.databaseURL}/events`)
+    fetch(`${clientCredentials.databaseURL}/events`, {
+      headers: {
+        Authorization: uid,
+      },
+    })
       .then((response) => response.json())
       .then(resolve)
       .catch(reject);
@@ -60,5 +65,33 @@ const deleteEvent = (eventId) =>
       .catch(reject);
   });
 
+const leaveEvent = (eventId, uid, setEvents) => {
+  // Make a delete request deleting user and event relationship in database IN EVENTGAMER
+  // Backend will read through the rows of the table and give back a true or false for whether the user has joined the event or not
+  fetch(`${clientCredentials.databaseURL}/events/${eventId}/leave`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid,
+    },
+    body: JSON.stringify({}),
+  })
+    .then(() => getEvents(uid))
+    .then(setEvents);
+};
+
+const joinEvent = (eventId, uid, setEvents) => {
+  // Make a post request to add the user and event relationship in the database
+  fetch(`${clientCredentials.databaseURL}/events/${eventId}/signup`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: uid,
+    },
+    body: JSON.stringify({}),
+  })
+    .then(() => getEvents(uid))
+    .then(setEvents);
+};
 // eslint-disable-next-line import/prefer-default-export
-export { getEvents, createEvent, updateEvent, getSingleEvent, deleteEvent };
+export { getEvents, createEvent, updateEvent, getSingleEvent, deleteEvent, joinEvent, leaveEvent };


### PR DESCRIPTION
This pull request adds join and leave functionality for events. Here's a summary of the changes:
Main Features Added:

Join Event: Users can join events they haven't joined yet
Leave Event: Users can leave events they've already joined

Key Changes:
1. Events Page (src/app/events/page.js)

Now passes user ID to getEvents() to get personalized event data
Passes joined status and setEvents function to each EventCard

2. EventCard Component (src/components/event/eventCard.js)

Added conditional Join/Leave buttons that show based on joined status
Added handleJoin() and handleLeave() functions
Updated PropTypes to include new joined and setEvents props

3. Event Data API (src/utils/data/eventData.js)

Updated getEvents() to accept uid parameter and include Authorization header
Added joinEvent() function - makes POST request to /events/{id}/signup
Added leaveEvent() function - makes DELETE request to /events/{id}/leave
Both functions refresh the events list after the operation

4. Auth Context (src/utils/context/authContext.js)

Minor cleanup - simplified user object creation

User Experience:

Users now see either a green "Join" button or yellow "Leave" button for each event
Clicking these buttons immediately updates the UI to reflect the change
The events list refreshes to show current join status across all events